### PR TITLE
cleanup, no more pipeline, .where

### DIFF
--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -214,7 +214,7 @@ foreach ($Category in $deployments.Keys) {
                         Write-Verbose "Deploying [Application = '$($app)'] to [CollectionName = '$TargetedCollection']"
     
                         #region define the splat to pass to New-CMApplicationDeployment
-                        If ($groupedFullCategoryAppList[$app].TargetedDP -eq 0) {
+                        If (($groupedFullCategoryAppList[$app].TargetedDP | Select-Object -Unique) -eq 0) {
                             Write-Verbose "$app found to not be distributed. Will distribute to $DistributionPointGroup as part of app deployment"
                             $newAppArgs["DistributeContent"] = $true
                             $newAppArgs["DistributionPointGroupName"] = $DistributionPointGroup

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -62,6 +62,7 @@
             Version 1.0.2: 2020-02-26
             Version 1.0.3: 2020-02-27
 #>
+#Requires -Modules SqlServer
 [CmdletBinding(SupportsShouldProcess = $true)]
 param (
     [Parameter(Mandatory = $true)]
@@ -161,7 +162,7 @@ $deployments = switch ($PSBoundParameters.ContainsKey('DeploymentJSON')) {
 # Loop through the $deployemnts
 ForEach ($deployment in $deployments.Keys) {
     # Pull a list of applications with that category
-    $appList = Invoke-SqlCmd -ServerInstance $CMDBServer -Database $CMDB -Query @"
+    $appList = SqlServer\Invoke-SqlCmd -ServerInstance $CMDBServer -Database $CMDB -Query @"
         SELECT apps.DisplayName
             , apps.CI_UniqueID
             , COUNT(dist.nalpath) AS [TargetedDP]
@@ -214,7 +215,7 @@ ForEach ($deployment in $deployments.Keys) {
     # Loop over each collection and ensure that there are no deployments that shouldn't be here
     ForEach ($collection in $deployments[$deployment].Collections) {
         $GoodAppListSqlArray = [string]::Format("'{0}'", [string]::Join("', '", $appList.LocalizedDisplayName))
-        $AppDeploysToRemove = Invoke-SqlCmd -ServerInstance $CMDBServer -Database $CMDB -Query @"
+        $AppDeploysToRemove = SqlServer\Invoke-SqlCmd -ServerInstance $CMDBServer -Database $CMDB -Query @"
         SELECT summ.SoftwareName
             , summ.CollectionID
             , summ.CollectionName

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -90,13 +90,13 @@ switch ($PSBoundParameters.ContainsKey('SQLServer')) {
     }
     #endregion if a SQLServer is provided, we will use that value, and assume the CMDB to be CM_$SiteCode
 
-    #region if a SQLServer is not provided we will attempt to gather the data from WMI on the SMS Provider
+    #region if a SQLServer is not provided we will attempt to gather the data from the registry
     $false {
         $CMDBInfo = Get-ItemProperty -Path 'registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SMS\SQL Server\'
         $CMDBServer = $CMDBInfo.Server
         $CMDB = $CMDBInfo.'Database Name'
     }
-    #endregion if a SQLServer is not provided we will attempt to gather the data from WMI on the SMS Provider
+    #endregion if a SQLServer is not provided we will attempt to gather the data from the registry
 }
 #endregion Gather site configuration, including SiteCode, Site Database Name, and SQLServer if not provided as a parameter
 

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -177,7 +177,7 @@ ForEach ($deployment in $deployments.Keys) {
 "@
 
     # Loop over each application that should be deployed and ensure it is
-    if ($appList.Count -gt 0) {
+    if ((Measure-Object -InputObject $appList).Count -gt 0) {
         ForEach ($app in $appList) {
             # Loop through the collections, if there are multiples
             ForEach ($collection in $deployments[$deployment].Collections) {
@@ -238,7 +238,7 @@ ForEach ($deployment in $deployments.Keys) {
 "@
 
         # Find apps that aren't in our AppList for this collection and remove the deployment
-        if ($AppDeploysToRemove.Count -gt 0) {
+        if ((Measure-Object -InputObject $AppDeploysToRemove).Count -gt 0) {
             foreach ($App in $AppDeploysToRemove) {
                 if ($PSCmdlet.ShouldProcess("[CollectionName = '$Collection'] [Application = '$($app.ApplicationName)']", "Remove-CMApplicationDeployment")) {
                     Write-Verbose "Removing deployment [Application = '$($app.SoftwareName)'] to [CollectionName = '$($app.CollectionName)']"

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -124,7 +124,7 @@ Push-Location
 Set-Location "$($SiteCode):\" @initParams
 
 # Set the required deployment args per collection
-$deployments = switch ($PSBoundParameters.Contains('DeploymentJSON')) {
+$deployments = switch ($PSBoundParameters.ContainsKey('DeploymentJSON')) {
     #region if a JSON file is provided, we will get the content of the file, convert from JSON, and then convert to a hash table
     $true {
         $Categories = (ConvertFrom-Json -InputObject (Out-String -InputObject (Get-Content -Path $DeploymentJSON))).psobject.Properties

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -225,11 +225,16 @@ ForEach ($deployment in $deployments.Keys) {
 "@
 
         # Find apps that aren't in our AppList for this collection and remove the deployment
-        foreach ($App in $AppDeploysToRemove) {
-            if ($PSCmdlet.ShouldProcess("[CollectionName = '$Collection'] [Application = '$($app.DisplayName)']", "Remove-CMApplicationDeployment")) {
-                Write-Verbose "Removing deployment [Application = '$($app.SoftwareName)'] to [CollectionName = '$($app.CollectionName)']"
-                Remove-CMApplicationDeployment -Name $App.SoftwareName -CollectionID $App.CollectionID -Force
+        if ($AppDeploysToRemove.Count -gt 0) {
+            foreach ($App in $AppDeploysToRemove) {
+                if ($PSCmdlet.ShouldProcess("[CollectionName = '$Collection'] [Application = '$($app.DisplayName)']", "Remove-CMApplicationDeployment")) {
+                    Write-Verbose "Removing deployment [Application = '$($app.SoftwareName)'] to [CollectionName = '$($app.CollectionName)']"
+                    Remove-CMApplicationDeployment -Name $App.SoftwareName -CollectionID $App.CollectionID -Force
+                }
             }
+        }
+        else {
+            Write-Verbose "There are no application deployments to remove for $collection"
         }
     }
 }

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -14,22 +14,23 @@
         You can either define your deployments in the script below, or you can provide a JSON file as a parameter,
         which contains an exported hashtable following the deployment template
 
+        Note: The 'Key' for this hashtable is the Category you will associate with apps that need deployed, for example
+        below, Helpdesk, and 'Fast Channel App' are the categories.
+        
         @{
-            "HelpDesk Deployments"     = @{
-                "Category"         = "Helpdesk"
-                "Collections"      = @("IT - Helpdesk")
-                "ApprovalRequired" = $false
-                "DeployAction"     = "Install"
-                "DeployPurpose"    = "Available"
-                "UserNotification" = "DisplayAll"
+            Helpdesk           = @{
+                Collection       = "IT - Helpdesk"
+                ApprovalRequired = $false
+                DeployAction     = "Install"
+                DeployPurpose    = "Available"
+                UserNotification = "DisplayAll"
             }
-            "Fast Channel Deployments" = @{
-                "Category"         = "Fast Channel App"
-                "Collections"      = @("Deploy - Fast Channel Deployment")
-                "ApprovalRequired" = $true
-                "DeployAction"     = "Install"
-                "DeployPurpose"    = "Available"
-                "UserNotification" = "DisplaySoftwareCenterOnly"
+            'Fast Channel App' = @{
+                Collection       = "Deploy - Fast Channel Deployment"
+                ApprovalRequired = $true
+                DeployAction     = "Install"
+                DeployPurpose    = "Available"
+                UserNotification = "DisplaySoftwareCenterOnly"
             }
         }
     .PARAMETER SiteServer

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -197,7 +197,6 @@ ForEach ($deployment in $deployments.Keys) {
                     "UserNotification" = $deployments[$deployment].UserNotification
                     "TimeBaseOn"       = "LocalTime"
                     "CollectionName"   = $collection
-                    "WhatIf"           = $true
                     "Verbose"          = $true
                 }
 

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -268,7 +268,7 @@ foreach ($Category in $deployments.Keys) {
             $false {
                 if ($PSCmdlet.ShouldProcess("[CollectionName = '$TargetedCollection'] [Application = '$($AppDeploy.ApplicationName)']", "Remove-CMApplicationDeployment")) {
                     Write-Verbose "Removing deployment [Application = '$($AppDeploy.ApplicationName)'] to [CollectionName = '$($AppDeploy.CollectionName)']"
-                    Remove-CMApplicationDeployment -Name $App.ApplicationName -CollectionID $App.CollectionID -Force
+                    Remove-CMApplicationDeployment -Name $AppDeploy.ApplicationName -CollectionID $AppDeploy.CollectionID -Force
                 }
             }
         }

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -1,4 +1,3 @@
-[CmdletBinding(SupportsShouldProcess = $true)]
 <#
     .SYNOPSIS
         Deploy applications to collections, based on Administrative Categories
@@ -63,6 +62,7 @@
             Version 1.0.2: 2020-02-26
             Version 1.0.3: 2020-02-27
 #>
+[CmdletBinding(SupportsShouldProcess = $true)]
 param (
     [Parameter(Mandatory = $true)]
     [string]$SiteServer,

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -241,7 +241,7 @@ ForEach ($deployment in $deployments.Keys) {
         if ((Measure-Object -InputObject $AppDeploysToRemove).Count -gt 0) {
             foreach ($App in $AppDeploysToRemove) {
                 if ($PSCmdlet.ShouldProcess("[CollectionName = '$Collection'] [Application = '$($app.ApplicationName)']", "Remove-CMApplicationDeployment")) {
-                    Write-Verbose "Removing deployment [Application = '$($app.SoftwareName)'] to [CollectionName = '$($app.CollectionName)']"
+                    Write-Verbose "Removing deployment [Application = '$($app.ApplicationName)'] to [CollectionName = '$($app.CollectionName)']"
                     Remove-CMApplicationDeployment -Name $App.ApplicationName -CollectionID $App.CollectionID -Force
                 }
             }

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -214,7 +214,7 @@ ForEach ($deployment in $deployments.Keys) {
 
     # Loop over each collection and ensure that there are no deployments that shouldn't be here
     ForEach ($collection in $deployments[$deployment].Collections) {
-        $GoodAppListSqlArray = [string]::Format("'{0}'", [string]::Join("', '", $appList.LocalizedDisplayName))
+        $GoodAppListSqlArray = [string]::Format("'{0}'", [string]::Join("', '", $appList.DisplayName))
         $AppDeploysToRemove = SqlServer\Invoke-SqlCmd -ServerInstance $CMDBServer -Database $CMDB -Query @"
         SELECT summ.SoftwareName
             , summ.CollectionID

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -92,15 +92,9 @@ switch ($PSBoundParameters.ContainsKey('SQLServer')) {
 
     #region if a SQLServer is not provided we will attempt to gather the data from WMI on the SMS Provider
     $false {
-        $getSQLServerInfoSplat = @{
-            Query        = "SELECT SiteObject FROM SMS_SiteSystemSummarizer WHERE Role = 'SMS SQL SERVER' and SiteCode = '$SiteCode' and ObjectType = 1"
-            ComputerName = $SiteServer
-            Namespace    = "root/sms/site_$siteCode"
-        }
-        
-        $DataSourceSQL = (Get-CimInstance @getSQLServerInfoSplat).SiteObject | Select-Object -Unique
-        $CMDBServer = $DataSourceSQL -replace '.*\\\\([A-Z0-9_-.]+)\\.*', '$+'
-        $CMDB = $DataSourceSQL -replace ".*\\([A-Z_0-9]*?)\\$", '$+'
+        $CMDBInfo = Get-ItemProperty -Path 'registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SMS\SQL Server\'
+        $CMDBServer = $CMDBInfo.Server
+        $CMDB = $CMDBInfo.'Database Name'
     }
     #endregion if a SQLServer is not provided we will attempt to gather the data from WMI on the SMS Provider
 }

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -59,7 +59,7 @@
         Author:    Vex
         Contributor: Chris Kibble (On a _massive_ level, thanks Chris!!!)
         Contributor: Cody Mathis (On a _miniscule_ level)
-        Version: 1.0.5
+        Version: 1.0.6
         Release Date: 2019-08-13
         Updated:
             Version 1.0.1: 2019-08-14
@@ -67,6 +67,7 @@
             Version 1.0.3: 2020-02-27
             Version 1.0.4: 2020-03-03
             Version 1.0.5: 2020-03-04
+            Version 1.0.6: 2020-03-05
 #>
 #Requires -Modules SqlServer
 [CmdletBinding(SupportsShouldProcess = $true)]
@@ -239,14 +240,13 @@ foreach ($Category in $deployments.Keys) {
                         }
 
                         $newAppArgs = @{
-                            "Name"             = $app
-                            "DeployAction"     = $deployments[$Category].DeployAction
-                            "DeployPurpose"    = $deployments[$Category].DeployPurpose
-                            "ApprovalRequired" = $deployments[$Category].ApprovalRequired
-                            "UserNotification" = $deployments[$Category].UserNotification
-                            "TimeBaseOn"       = "LocalTime"
-                            "CollectionName"   = $TargetedCollection
-                            "Verbose"          = $true
+                            Name             = $app
+                            DeployAction     = $deployments[$Category].DeployAction
+                            DeployPurpose    = $deployments[$Category].DeployPurpose
+                            ApprovalRequired = $deployments[$Category].ApprovalRequired
+                            UserNotification = $deployments[$Category].UserNotification
+                            TimeBaseOn       = "LocalTime"
+                            CollectionName   = $TargetedCollection
                         }
                         #endregion define the splat to pass to New-CMApplicationDeployment
 

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -125,19 +125,25 @@ Push-Location
 Set-Location "$($SiteCode):\" @initParams
 
 # Set the required deployment args per collection
-$deployments = switch ($PSBoundParameters.ContainsKey('DeploymentJSON')) {
+switch ($PSBoundParameters.ContainsKey('DeploymentJSON')) {
     #region if a JSON file is provided, we will get the content of the file, convert from JSON, and then convert to a hash table
     $true {
-        $Categories = (ConvertFrom-Json -InputObject (Out-String -InputObject (Get-Content -Path $DeploymentJSON))).psobject.Properties
+        $deployments = @{ }
+        $Categories = (ConvertFrom-Json -InputObject (Out-String -InputObject (Get-Content -Path $DeploymentJSON))).PSObject.Properties
         foreach ($Category in $Categories) {
-            @{ $Category.Name = $Category.Value }
+            $Values = $Category.Value.PSObject.Properties
+            $ValueHashTable = @{ }
+            foreach ($Value in $Values) {
+                $ValueHashTable[$Value.Name] = $Value.Value
+            }
+            $deployments[$Category.Name] = $ValueHashTable
         }
     }
     #endregion if a JSON file is provided, we will get the content of the file, convert from JSON, and then convert to a hash table
 
     #region if a JSON file is not provided, the below section should be populated to match your desired category based deployments
     $false {
-        @{
+        $deployments = @{
             "HelpDesk Deployments"     = @{
                 "Category"         = "Helpdesk"
                 "Collections"      = @("IT - Helpdesk")

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -216,7 +216,7 @@ ForEach ($deployment in $deployments.Keys) {
     ForEach ($collection in $deployments[$deployment].Collections) {
         $GoodAppListSqlArray = [string]::Format("'{0}'", [string]::Join("', '", $appList.DisplayName))
         $AppDeploysToRemove = SqlServer\Invoke-SqlCmd -ServerInstance $CMDBServer -Database $CMDB -Query @"
-        SELECT summ.ApplicationName
+        SELECT appass.ApplicationName
             , summ.CollectionID
             , summ.CollectionName
         FROM v_DeploymentSummary summ

--- a/Scripts/Deploy-AppByCategory.ps1
+++ b/Scripts/Deploy-AppByCategory.ps1
@@ -26,7 +26,7 @@
 
 # Site configuration
 $ProviderMachineName = "cm.contoso.com" # SMS Provider machine FQDN
-$SiteCode = (Get-CimInstance -Query "SELECT SiteCode FROM SMS_ProviderLocation WHERE Machine = '$ProviderMachineName'" -Namespace root\SMS).SiteCode
+$SiteCode = (Get-CimInstance -Query "SELECT SiteCode FROM SMS_ProviderLocation WHERE Machine = '$ProviderMachineName'" -Namespace root\SMS -ComputerName $ProviderMachineName).SiteCode
 
 # Customizations
 $initParams = @{ }


### PR DESCRIPTION
Automatically determine site code, only need SMS Provider FQDN.

Remove the use of pipeline

$null on left side of comparison to keep pester tests happy

Implement 'foreach' loop instead of .where filter for cleaning up unneeded / bad deployments

Switch to SQL queries to improve run time

Testing with @TeslaSysA to ensure functionality.